### PR TITLE
Add "tooltips" to toolbar buttons for better accessibility

### DIFF
--- a/airsync-mac/Screens/HomeScreen/AppContentView.swift
+++ b/airsync-mac/Screens/HomeScreen/AppContentView.swift
@@ -47,11 +47,12 @@ struct AppContentView: View {
                         .toolbar {
                             if (appState.notifications.count > 0){
                                 ToolbarItem(placement: .primaryAction) {
-                                    Button {
+                                Button {
                                         notificationStacks.toggle()
                                     } label: {
                                         Label("Toggle Notification Stacks", systemImage: notificationStacks ? "mail" : "mail.stack")
                                     }
+                                    .help(notificationStacks ? "Switch to stacked view" : "Switch to expanded view")
                                 }
                                 ToolbarItem(placement: .primaryAction) {
                                     Button {
@@ -59,6 +60,7 @@ struct AppContentView: View {
                                     } label: {
                                         Label("Clear", systemImage: "wind")
                                     }
+                                    .help("Clear all notifications")
                                 .badge(appState.notifications.count)
                                 }
                             }
@@ -79,6 +81,7 @@ struct AppContentView: View {
                                         NSWorkspace.shared.open(url)
                                     }
                                 }
+                                .help("Report issues or suggest features")
                             }
 
                             ToolbarItem(placement: .primaryAction) {
@@ -87,6 +90,7 @@ struct AppContentView: View {
                                 } label: {
                                     Label("About", systemImage: "info")
                                 }
+                                .help("View app information and version details")
                             }
                         }
                 }
@@ -111,6 +115,7 @@ struct AppContentView: View {
                         Button(tab.rawValue, systemImage: tab.icon){}
                             .labelStyle(.iconOnly)
                             .tag(tab)
+                            .help(tab.rawValue)
                     }
                 }
                 .pickerStyle(.palette)


### PR DESCRIPTION
# #31 **[Feature Request]**: Tooltips on Toolbar Icons

After considering the feature request, I decided to go ahead and knock out this feature.
Updated the AppContentView.swift file to show Tooltips with the .help method.

## Screen Captures:

### Whole App view
<img width="1002" height="742" alt="image" src="https://github.com/user-attachments/assets/b9f7e5da-6992-4a07-88e4-cdf5259cbec6" />

### Tabs
<img width="279" height="153" alt="image" src="https://github.com/user-attachments/assets/ae9ae986-5402-4639-a605-95c86e8f36ea" />
<img width="281" height="146" alt="image" src="https://github.com/user-attachments/assets/d1f1368d-dc15-46ff-b203-440bec44f7ec" />
<img width="307" height="167" alt="image" src="https://github.com/user-attachments/assets/66b4b594-b443-4c1b-b08c-88d8f6541ff3" />

### Report and Info buttons
<img width="492" height="202" alt="image" src="https://github.com/user-attachments/assets/8d85bc9b-c009-4718-a83b-f17cf00de9c0" />
<img width="527" height="163" alt="image" src="https://github.com/user-attachments/assets/5e84ebcf-3517-4fe5-ba9a-047209f2af64" />

### View Toggle and Clear Notifications
<img width="816" height="343" alt="image" src="https://github.com/user-attachments/assets/1c2a6129-02b2-4f7c-af4b-2b1f35b7aea0" />
<img width="877" height="255" alt="image" src="https://github.com/user-attachments/assets/07ce2b93-12f8-4766-a9f3-4d409a94c23c" />

---

## Testing
This was updated in Warp / NeoVim, and tested in XCode on a Macbook Air M3 running MacOS 15.6.
No functionality seemed to be impacted, and the toolbar/tooltips functioned as expected.
