### PR TITLE
Fix huge Search font in Apps menu

### DIFF
--- a/airsync-mac/Screens/HomeScreen/AppContentView.swift
+++ b/airsync-mac/Screens/HomeScreen/AppContentView.swift
@@ -90,7 +90,6 @@ struct AppContentView: View {
 
                 case .apps:
                     AppsView()
-                    .font(.largeTitle)
                     .transition(.blurReplace)
 
                 case .transfers:


### PR DESCRIPTION
Fixes the huge search font in the apps menu to make the UI more consistent looking.

## Screenshots

### Before
![CleanShot 2025-09-14 at 09 34 43](https://github.com/user-attachments/assets/e1524b07-da11-4970-acd8-67ae695d761f)

### After
![CleanShot 2025-09-14 at 09 37 21](https://github.com/user-attachments/assets/ab3f3b4b-9f6b-46b9-b8b5-7a5da7f973fc)
