### PR TITLE
Develop

### DIFF
--- a/airsync-mac/Components/Custom/LicenseView.swift
+++ b/airsync-mac/Components/Custom/LicenseView.swift
@@ -284,6 +284,10 @@ This app bundles adb from the Android SDK Platform Tools (Apache License 2.0).
 This app includes scrcpy (Apache License 2.0) by Genymobile.
 Source: https://github.com/Genymobile/scrcpy
 """)
+            ExpandableLicenseSection(title: "External: media-control", content: """
+This app communicates with the media-control cli the use install via Homebrew. Huge thanks tot he amazing project giving us the ability to create awesome features <3
+Source: https://github.com/ungive/media-control
+""")
         }
     }
 }

--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -72,6 +72,9 @@ class AppState: ObservableObject {
         self.scrcpyResolution = UserDefaults.standard.integer(forKey: "scrcpyResolution")
         if self.scrcpyResolution == 0 { self.scrcpyResolution = 1200 }
 
+    // Initialize persisted UI toggles
+    self.isMusicCardHidden = UserDefaults.standard.bool(forKey: "isMusicCardHidden")
+
         self.myDevice = Device(
             name: name,
             ipAddress: WebSocketServer.shared
@@ -200,6 +203,13 @@ class AppState: ObservableObject {
     @Published var sendNowPlayingStatus: Bool {
         didSet {
             UserDefaults.standard.set(sendNowPlayingStatus, forKey: "sendNowPlayingStatus")
+        }
+    }
+
+    // Whether the media player card is hidden on the PhoneView
+    @Published var isMusicCardHidden: Bool = false {
+        didSet {
+            UserDefaults.standard.set(isMusicCardHidden, forKey: "isMusicCardHidden")
         }
     }
 

--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -53,6 +53,11 @@ class AppState: ObservableObject {
             .bool(forKey: "hideDockIcon")
         self.dismissNotif = UserDefaults.standard
             .bool(forKey: "dismissNotif")
+        
+        // Default to true for backward compatibility - existing behavior should continue
+        let savedNowPlayingStatus = UserDefaults.standard.object(forKey: "sendNowPlayingStatus")
+        self.sendNowPlayingStatus = savedNowPlayingStatus == nil ? true : UserDefaults.standard.bool(forKey: "sendNowPlayingStatus")
+        
         if isClipboardSyncEnabled {
             startClipboardMonitoring()
         }
@@ -189,6 +194,12 @@ class AppState: ObservableObject {
     @Published var dismissNotif: Bool {
         didSet {
             UserDefaults.standard.set(dismissNotif, forKey: "dismissNotif")
+        }
+    }
+
+    @Published var sendNowPlayingStatus: Bool {
+        didSet {
+            UserDefaults.standard.set(sendNowPlayingStatus, forKey: "sendNowPlayingStatus")
         }
     }
 

--- a/airsync-mac/Core/Storage/UserDefaults.swift
+++ b/airsync-mac/Core/Storage/UserDefaults.swift
@@ -25,6 +25,7 @@ extension UserDefaults {
         static let manualPositionCoords = "manualPositionCoords"
         static let continueApp = "continueApp"
         static let directKeyInput = "directKeyInput"
+        static let sendNowPlayingStatus = "sendNowPlayingStatus"
 
         static let notificationStacks = "notificationStacks"
     }
@@ -116,6 +117,11 @@ extension UserDefaults {
     var directKeyInput: Bool {
         get { bool(forKey: Keys.directKeyInput)}
         set { set(newValue, forKey: Keys.directKeyInput)}
+    }
+    
+    var sendNowPlayingStatus: Bool {
+        get { bool(forKey: Keys.sendNowPlayingStatus)}
+        set { set(newValue, forKey: Keys.sendNowPlayingStatus)}
     }
 }
 

--- a/airsync-mac/Core/Storage/UserDefaults.swift
+++ b/airsync-mac/Core/Storage/UserDefaults.swift
@@ -26,6 +26,7 @@ extension UserDefaults {
         static let continueApp = "continueApp"
         static let directKeyInput = "directKeyInput"
         static let sendNowPlayingStatus = "sendNowPlayingStatus"
+    static let isMusicCardHidden = "isMusicCardHidden"
 
         static let notificationStacks = "notificationStacks"
     }
@@ -122,6 +123,11 @@ extension UserDefaults {
     var sendNowPlayingStatus: Bool {
         get { bool(forKey: Keys.sendNowPlayingStatus)}
         set { set(newValue, forKey: Keys.sendNowPlayingStatus)}
+    }
+
+    var isMusicCardHidden: Bool {
+        get { bool(forKey: Keys.isMusicCardHidden) }
+        set { set(newValue, forKey: Keys.isMusicCardHidden) }
     }
 }
 

--- a/airsync-mac/Core/Util/BatteryInfo.swift
+++ b/airsync-mac/Core/Util/BatteryInfo.swift
@@ -1,0 +1,59 @@
+//
+//  BatteryInfo.swift
+//  AirSync
+//
+//  Created by Sameera Sandakelum on 2025-09-18.
+//
+
+import Foundation
+
+struct BatteryStatus {
+    let percentage: Int
+    let isCharging: Bool
+}
+
+class BatteryInfo {
+    static func fetchStatus() -> BatteryStatus? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        process.arguments = ["-g", "batt"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            print("Failed to run pmset: \(error)")
+            return nil
+        }
+
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+        guard let output = String(data: data, encoding: .utf8) else { return nil }
+
+        // Example output:
+        // Now drawing from 'Battery Power'
+        // -InternalBattery-0  87%; discharging; (no estimate)
+
+        let lines = output.components(separatedBy: .newlines)
+        guard let batteryLine = lines.first(where: { $0.contains("%") }) else { return nil }
+
+        // Extract percentage
+        let percentageRegex = try! NSRegularExpression(pattern: "(\\d+)%")
+        let percentMatch = percentageRegex.firstMatch(in: batteryLine, range: NSRange(batteryLine.startIndex..., in: batteryLine))
+        let percentage: Int
+        if let match = percentMatch, let range = Range(match.range(at: 1), in: batteryLine) {
+            percentage = Int(batteryLine[range]) ?? 0
+        } else {
+            percentage = 0
+        }
+
+        // Check charging/discharging - when unplugged it shows "discharging"
+        let isCharging = !batteryLine.contains("discharging") && (batteryLine.contains("charging") || batteryLine.contains("AC Power"))
+
+        return BatteryStatus(percentage: percentage, isCharging: isCharging)
+    }
+}

--- a/airsync-mac/Core/Util/NowPlaying/NowPlayingCLI.swift
+++ b/airsync-mac/Core/Util/NowPlaying/NowPlayingCLI.swift
@@ -9,13 +9,76 @@ import Foundation
 
 class NowPlayingCLI {
     static let shared = NowPlayingCLI()
-    private let path = "/opt/homebrew/bin/media-control"
+
+    // Potential fallback paths for Apple Silicon and Intel Homebrew
+    static let possibleMediaControlPaths = [
+        "/opt/homebrew/bin/media-control", // Apple Silicon Homebrew
+        "/usr/local/bin/media-control"     // Intel Homebrew
+    ]
+
+    // Cache resolved path to avoid repeated lookups
+    private var cachedPath: String?
 
     private init() {}
 
-    func fetchNowPlaying(completion: @escaping (NowPlayingInfo?) -> Void) {
+    private func resolveBinaryPath() -> String? {
+        if let cachedPath { return cachedPath }
+        if let path = findExecutable(named: "media-control", fallbackPaths: NowPlayingCLI.possibleMediaControlPaths) {
+            cachedPath = path
+            return path
+        }
+        return nil
+    }
+
+    // MARK: - Local binary finder (modeled after ADBConnector)
+    private func findExecutable(named name: String, fallbackPaths: [String]) -> String? {
+        if isExecutableAvailable(name) {
+            let path = getExecutablePath(name)
+            if !path.isEmpty { return path }
+        }
+        for path in fallbackPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    private func getExecutablePath(_ name: String) -> String {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/media-control")
+        process.launchPath = "/usr/bin/which"
+        process.arguments = [name]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ""
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return output
+    }
+
+    private func isExecutableAvailable(_ name: String) -> Bool {
+        let path = getExecutablePath(name)
+        return !path.isEmpty
+    }
+
+    func fetchNowPlaying(completion: @escaping (NowPlayingInfo?) -> Void) {
+        guard let binPath = resolveBinaryPath() else {
+            // media-control not available; gracefully return nil
+            print("media-control binary not found. Install with: brew install media-control")
+            completion(Optional<NowPlayingInfo>.none)
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binPath)
         process.arguments = ["get"]
 
         let pipe = Pipe()
@@ -35,7 +98,7 @@ class NowPlayingCLI {
         process.terminationHandler = { _ in
             handle.readabilityHandler = nil
             guard !buffer.isEmpty else {
-                DispatchQueue.main.async { completion(nil) }
+                DispatchQueue.main.async { completion(Optional<NowPlayingInfo>.none) }
                 return
             }
 
@@ -62,7 +125,7 @@ class NowPlayingCLI {
             try process.run()
         } catch {
             print("Failed to run media-control get:", error)
-            completion(nil)
+            completion(Optional<NowPlayingInfo>.none)
         }
     }
 
@@ -77,8 +140,12 @@ class NowPlayingCLI {
     func stop() { runCommand("stop") }
 
     private func runCommand(_ cmd: String) {
+        guard let binPath = resolveBinaryPath() else {
+            print("media-control binary not found. Install with: brew install media-control")
+            return
+        }
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: path)
+        process.executableURL = URL(fileURLWithPath: binPath)
         process.arguments = [cmd]
         process.standardOutput = Pipe()
         process.standardError = Pipe()

--- a/airsync-mac/Core/WebSocket/WebSocketServer.swift
+++ b/airsync-mac/Core/WebSocket/WebSocketServer.swift
@@ -769,7 +769,7 @@ class WebSocketServer: ObservableObject {
 
         let statusDict: [String: Any] = [
             "battery": [
-                "level": batteryLevel,
+                "level": batteryLevel, // -1 for non-MacBooks, 0-100 for MacBooks
                 "isCharging": isCharging
             ],
             "isPaired": isPaired,

--- a/airsync-mac/Core/WebSocket/WebSocketServer.swift
+++ b/airsync-mac/Core/WebSocket/WebSocketServer.swift
@@ -286,6 +286,9 @@ class WebSocketServer: ObservableObject {
 				if UserDefaults.standard.hasPairedDeviceOnce == false {
 					UserDefaults.standard.hasPairedDeviceOnce = true
 				}
+				
+				// Send Mac info response to Android
+				sendMacInfoResponse()
             }
 
 
@@ -579,6 +582,11 @@ class WebSocketServer: ObservableObject {
             // This case handles responses from Android to Mac media control responses
             // Currently not needed as Mac sends responses to Android, not vice versa
             print("Received macMediaControlResponse (not typically expected)")
+
+        case .macInfo:
+            // This case handles macInfo messages from Android to Mac
+            // Currently not expected as Mac sends macInfo to Android, not vice versa
+            print("Received macInfo message from Android (not typically expected)")
         }
 
 
@@ -629,6 +637,43 @@ class WebSocketServer: ObservableObject {
         }
         """
         sendToFirstAvailable(message: message)
+    }
+
+    private func sendMacInfoResponse() {
+        // Get Mac device information
+        let macName = AppState.shared.myDevice?.name ?? (Host.current().localizedName ?? "My Mac")
+        let categoryType = DeviceTypeUtil.deviceTypeDescription()
+        let exactDeviceName = DeviceTypeUtil.deviceFullDescription()
+        let isPlusSubscription = AppState.shared.isPlus
+        
+        // Get list of saved app package names
+        let savedAppPackages = Array(AppState.shared.androidApps.keys)
+        
+        let macInfo = MacInfo(
+            name: macName,
+            categoryType: categoryType,
+            exactDeviceName: exactDeviceName,
+            isPlusSubscription: isPlusSubscription,
+            savedAppPackages: savedAppPackages
+        )
+        
+        do {
+            let jsonData = try JSONEncoder().encode(macInfo)
+            if let jsonDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
+                let messageDict: [String: Any] = [
+                    "type": "macInfo",
+                    "data": jsonDict
+                ]
+                
+                let messageJsonData = try JSONSerialization.data(withJSONObject: messageDict, options: [])
+                if let messageJsonString = String(data: messageJsonData, encoding: .utf8) {
+                    sendToFirstAvailable(message: messageJsonString)
+                    print("Sent Mac info response to Android device")
+                }
+            }
+        } catch {
+            print("Error creating Mac info response: \(error)")
+        }
     }
 
     // MARK: - Sending Helpers

--- a/airsync-mac/Info.plist
+++ b/airsync-mac/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>AndroidVersion</key>
-	<string>2.0.30</string>
+	<string>2.0.32</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/airsync-mac/Model/MacInfo.swift
+++ b/airsync-mac/Model/MacInfo.swift
@@ -1,0 +1,16 @@
+//
+//  MacInfo.swift
+//  airsync-mac
+//
+//  Created by Sameera Sandakelum on 2025-09-18.
+//
+
+import Foundation
+
+struct MacInfo: Codable {
+    let name: String
+    let categoryType: String
+    let exactDeviceName: String
+    let isPlusSubscription: Bool
+    let savedAppPackages: [String]
+}

--- a/airsync-mac/Model/Message.swift
+++ b/airsync-mac/Model/Message.swift
@@ -8,6 +8,7 @@ import Foundation
 
 enum MessageType: String, Codable {
     case device
+    case macInfo
     case notification
     case notificationAction
     case notificationActionResponse

--- a/airsync-mac/Screens/HomeScreen/PhoneView/DeviceStatusView.swift
+++ b/airsync-mac/Screens/HomeScreen/PhoneView/DeviceStatusView.swift
@@ -16,9 +16,11 @@ struct DeviceStatusView: View {
 
     var body: some View {
         HStack {
-            HStack(spacing: 12) {
+            HStack(spacing: 8) {
                 let batteryLevel = appState.status?.battery.level ?? 100
                 let batteryIsCharging = appState.status?.battery.isCharging ?? false
+
+
                 HStack{
                     Image(systemName: batteryIcon(for: batteryLevel, isCharging: batteryIsCharging))
                         .help("\(batteryLevel)%")
@@ -26,13 +28,17 @@ struct DeviceStatusView: View {
                     Text("\(batteryLevel)%")
                         .font(.caption2)
                 }
+                .padding(.leading, 4)
 
                 let volume = appState.status?.music.volume ?? 100
                 let isMuted = appState.status?.music.isMuted ?? false
-                Image(systemName: volumeIcon(for: volume, isMuted: isMuted))
-                    .help(isMuted ? "Muted" : "\(volume)%")
-                    .contentTransition(.symbolEffect)
-                    .onTapGesture {
+
+                GlassButtonView(
+                    label: "Music Player",
+                    systemImage: volumeIcon(for: volume, isMuted: isMuted),
+                    iconOnly: true,
+                    primary: false,
+                    action: {
                         if AppState.shared.isPlus && AppState.shared.licenseCheck {
                             if let currentVolume = appState.status?.music.volume {
                                 tempVolume = Double(currentVolume)
@@ -42,6 +48,9 @@ struct DeviceStatusView: View {
                             showingPlusPopover = true
                         }
                     }
+                )
+                .help(isMuted ? "Muted" : "\(volume)%")
+                .contentTransition(.symbolEffect)
                     .popover(isPresented: $showingVolumePopover, arrowEdge: .bottom) {
                         VStack {
                             HStack {
@@ -68,24 +77,28 @@ struct DeviceStatusView: View {
                     .popover(isPresented: $showingPlusPopover, arrowEdge: .bottom) {
                         PlusFeaturePopover(message: "Control volume with AirSync+")
                     }
+
+
+                GlassButtonView(
+                    label: "Music Player",
+                    systemImage: appState.status?.music.isPlaying == true ? "play.rectangle" : "music.note",
+                    iconOnly: true,
+                    primary: false,
+                    action: {
+                        withAnimation(.easeInOut(duration: 0.28)) {
+                            appState.isMusicCardHidden.toggle()
+                        }
+                    }
+                )
+                .help("Show player")
             }
-            .padding(10)
+            .padding(4)
             .applyGlassViewIfAvailable()
             .animation(
                 .easeInOut(duration: 0.25),
                 value: "\(appState.status?.battery.level ?? 0)-\(appState.status?.music.volume ?? 0)"
             )
 
-            GlassButtonView(
-                label: "Music Player",
-                systemImage: appState.status?.music.isPlaying == true ? "play" : "music.note",
-                iconOnly: true,
-                primary: false,
-                action: {
-                    appState.isMusicCardHidden.toggle()
-                }
-            )
-            .help("Show player")
         }
     }
 

--- a/airsync-mac/Screens/HomeScreen/PhoneView/DeviceStatusView.swift
+++ b/airsync-mac/Screens/HomeScreen/PhoneView/DeviceStatusView.swift
@@ -15,7 +15,7 @@ struct DeviceStatusView: View {
     @State private var showingPlusPopover = false
 
     var body: some View {
-        ZStack {
+        HStack {
             HStack(spacing: 12) {
                 let batteryLevel = appState.status?.battery.level ?? 100
                 let batteryIsCharging = appState.status?.battery.isCharging ?? false
@@ -75,6 +75,17 @@ struct DeviceStatusView: View {
                 .easeInOut(duration: 0.25),
                 value: "\(appState.status?.battery.level ?? 0)-\(appState.status?.music.volume ?? 0)"
             )
+
+            GlassButtonView(
+                label: "Music Player",
+                systemImage: appState.status?.music.isPlaying == true ? "play" : "music.note",
+                iconOnly: true,
+                primary: false,
+                action: {
+                    appState.isMusicCardHidden.toggle()
+                }
+            )
+            .help("Show player")
         }
     }
 

--- a/airsync-mac/Screens/HomeScreen/PhoneView/PhoneView.swift
+++ b/airsync-mac/Screens/HomeScreen/PhoneView/PhoneView.swift
@@ -199,6 +199,10 @@ struct ScreenView: View {
             .easeInOut(duration: 0.35),
             value: AppState.shared.adbConnected
         )
+        .animation(
+            .easeInOut(duration: 0.28),
+            value: appState.isMusicCardHidden
+        )
     }
 }
 

--- a/airsync-mac/Screens/HomeScreen/PhoneView/PhoneView.swift
+++ b/airsync-mac/Screens/HomeScreen/PhoneView/PhoneView.swift
@@ -120,7 +120,8 @@ struct ScreenView: View {
 
             if let music = appState.status?.music,
                let title = appState.status?.music.title.trimmingCharacters(in: .whitespacesAndNewlines),
-               !title.isEmpty {
+               !title.isEmpty,
+               !appState.isMusicCardHidden {
 
                 MediaPlayerView(music: music)
                     .transition(.opacity.combined(with: .scale))

--- a/airsync-mac/Screens/OnboardingView/InstallAndroidView.swift
+++ b/airsync-mac/Screens/OnboardingView/InstallAndroidView.swift
@@ -20,20 +20,6 @@ struct InstallAndroidView: View {
                 .font(.title)
                 .multilineTextAlignment(.center)
                 .padding()
-            Text("The app is currently pending approval on Google Play in Early Access.")
-                .font(.callout)
-                .multilineTextAlignment(.center)
-
-            GlassButtonView(
-                label: "First, Join the Google group",
-                size: .extraLarge,
-                action: {
-                    if let url = URL(string: "https://groups.google.com/forum/#!forum/airsync-testing/join") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-            )
-            .transition(.identity)
 
             if let qrImage = qrImage {
                 Image(decorative: qrImage, scale: 1.0)
@@ -48,13 +34,13 @@ struct InstallAndroidView: View {
                     .frame(width: 100, height: 100)
             }
 
-            Text("Scan the QR code to download the app from Google Play Early Access or use the below link.")
+            Text("Scan the QR code to download the app from Google Play or use the below link.")
                 .multilineTextAlignment(.center)
                 .padding()
 
 
             GlassButtonView(
-                label: "Enroll and install from web",
+                label: "Install from web",
                 size: .extraLarge,
                 action: {
                     if let url = URL(string: "https://play.google.com/apps/testing/com.sameerasw.airsync") {

--- a/airsync-mac/Screens/OnboardingView/MirroringSetupView.swift
+++ b/airsync-mac/Screens/OnboardingView/MirroringSetupView.swift
@@ -13,23 +13,31 @@ struct MirroringSetupView: View {
 
     @State private var adbAvailable = false
     @State private var scrcpyAvailable = false
+    @State private var mediaControlAvailable = false
     @State private var checking = true
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("Optional Android mirroring setup")
+            Text("Optional Setup - Android Mirror and Media Playback")
                 .font(.title)
                 .multilineTextAlignment(.center)
                 .padding()
 
-            Text("AirSync can mirror your Android screen to your Mac using ADB and scrcpy. This allows you to control your Android device from your Mac. But mirroring is an optional AirSync+ feature which you may or may not need. ADB and scrcpy are required for mirroring.")
+            Text("AirSync can mirror your Android screen to your Mac using ADB and scrcpy. This allows you to control your Android device from your Mac. But mirroring is an optional AirSync+ feature which you may or may not need. ADB and scrcpy are required for mirroring. For rich media features (showing the current song and controlling playback), we recommend installing the optional media-control CLI as well.")
                 .font(.body)
                 .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: 500)
+
+
+            Text("media-control is optional, but enables Now Playing sync to Android and media keys from Mac. Recommended.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.leading)
                 .frame(maxWidth: 500)
 
             if checking {
-                ProgressView("Checking for ADB and scrcpy...")
+                ProgressView("Checking for ADB, scrcpy, and media-control...")
                     .frame(width: 200, height: 50)
             } else {
                 VStack(spacing: 16) {
@@ -45,8 +53,16 @@ struct MirroringSetupView: View {
                         Text("scrcpy \(scrcpyAvailable ? "found" : "not found")")
                     }
 
-                    if !adbAvailable || !scrcpyAvailable {
-                        Text("Install with Homebrew running the following commands terminal:")
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: mediaControlAvailable ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundColor(mediaControlAvailable ? .green : .red)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("media-control \(mediaControlAvailable ? "found" : "not found")")
+                        }
+                    }
+
+                    if !adbAvailable || !scrcpyAvailable || !mediaControlAvailable {
+                        Text("Install with Homebrew by running the following commands in Terminal:")
                             .font(.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
@@ -59,6 +75,9 @@ struct MirroringSetupView: View {
                             }
                             if !scrcpyAvailable {
                                 commandRow("brew install scrcpy")
+                            }
+                            if !mediaControlAvailable {
+                                commandRow("brew install media-control")
                             }
                         }
                         .padding()
@@ -80,7 +99,7 @@ struct MirroringSetupView: View {
                         )
                         .transition(.identity)
                     } else {
-                        Text("Great! Both ADB and scrcpy are available.")
+                        Text("Great! ADB, scrcpy, and media-control are available.")
                             .font(.callout)
                             .foregroundColor(.green)
                     }
@@ -116,12 +135,14 @@ struct MirroringSetupView: View {
         DispatchQueue.global(qos: .background).async {
             let adbFound = ADBConnector.findExecutable(named: "adb", fallbackPaths: ADBConnector.possibleADBPaths) != nil
             let scrcpyFound = ADBConnector.findExecutable(named: "scrcpy", fallbackPaths: ADBConnector.possibleScrcpyPaths) != nil
+            let mediaFound = ADBConnector.findExecutable(named: "media-control", fallbackPaths: ["/opt/homebrew/bin/media-control", "/usr/local/bin/media-control"]) != nil
 
             // let scrcpyFound = false
 
             DispatchQueue.main.async {
                 self.adbAvailable = adbFound
                 self.scrcpyAvailable = scrcpyFound
+                self.mediaControlAvailable = mediaFound
                 self.checking = false
             }
         }

--- a/airsync-mac/Screens/OnboardingView/PlusFeaturesView.swift
+++ b/airsync-mac/Screens/OnboardingView/PlusFeaturesView.swift
@@ -27,6 +27,7 @@ struct PlusFeaturesView: View {
                     featureRow(icon: "macbook.and.iphone", title: "Android Mirroring", description: "Mirror your Android screen and apps to your Mac with full control, wirelessly")
                     featureRow(icon: "music.note", title: "Media Controls", description: "Control music playback and volume directly from your Mac")
                     featureRow(icon: "desktopcomputer", title: "Wireless Desktop Mode", description: "Use the phone in a familiar way, with full desktop controls")
+                    featureRow(icon: "globe", title: "Continue Browsing", description: "Simply copy or share a link to prompt it open on the other device")
                     featureRow(icon: "bell.badge", title: "Advanced Notifications", description: "Enhanced notification management and customization", soon: true)
                     featureRow(icon: "battery.25percent", title: "Low Battery Alerts", description: "Get notified when your Android device needs charging", soon: true)
                     featureRow(icon: "widget.small.badge.plus", title: "Widgets", description: "Synced widgets with device status and more", soon: true)

--- a/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
+++ b/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
@@ -320,6 +320,13 @@ struct SettingsFeaturesView: View {
                     .toggleStyle(.switch)
             }
 
+            HStack{
+                Label("Send now playing status", systemImage: "play.circle")
+                Spacer()
+                Toggle("", isOn: $appState.sendNowPlayingStatus)
+                    .toggleStyle(.switch)
+            }
+
         }
         .padding()
         .onAppear{


### PR DESCRIPTION
This pull request introduces several improvements and new features to the AirSync macOS app, focusing on device status reporting, user preferences, and support for external tools. The most significant changes include robust detection and usage of the `media-control` CLI, new user settings for controlling device status sharing, improved battery information handling, and enhanced communication with Android devices.

**Device Status and Media Info Reporting**

* Added a new user setting `sendNowPlayingStatus` to allow users to control whether their Mac's media playback info is shared with connected Android devices. This is persisted in `UserDefaults` and defaults to `true` for backward compatibility. [[1]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR56-R60) [[2]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR203-R215) [[3]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R28-R29) [[4]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R122-R131)
* Updated `NowPlayingViewModel` to respect the `sendNowPlayingStatus` toggle, sending device status with or without music info accordingly. Also improved logging and ensured device status is always sent, even if music info is disabled. [[1]](diffhunk://#diff-9382d7eb692f61e12a8a0f3a1d98fd0d200be3365930fa1199b1efac26061348R75-R82) [[2]](diffhunk://#diff-9382d7eb692f61e12a8a0f3a1d98fd0d200be3365930fa1199b1efac26061348R106-R205)
* Added a new toggle `isMusicCardHidden` to persist the visibility of the music card UI element via `UserDefaults`. [[1]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR75-R77) [[2]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR203-R215) [[3]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R28-R29) [[4]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R122-R131)

**Battery Information Handling**

* Replaced the previous IOKit-based battery info retrieval with a new `BatteryInfo` utility that uses the `pmset` command for more reliable battery status detection on MacBooks, and provides robust fallback for desktop Macs. [[1]](diffhunk://#diff-031218df0537e0a4d57366a7af65fe9ec28fa6645c2bdc7f1a37c2adebfa9b10R1-R59) [[2]](diffhunk://#diff-9382d7eb692f61e12a8a0f3a1d98fd0d200be3365930fa1199b1efac26061348R106-R205)

**External Tool Support**

* Enhanced the `NowPlayingCLI` to robustly locate the `media-control` binary, supporting both Apple Silicon and Intel Homebrew paths, and added fallback logic to gracefully handle missing binaries. [[1]](diffhunk://#diff-35cb53470bfd5adf8d0f4d442e0b308aaa13190231ef58ce3325013613796f9fL12-R81) [[2]](diffhunk://#diff-35cb53470bfd5adf8d0f4d442e0b308aaa13190231ef58ce3325013613796f9fL38-R101) [[3]](diffhunk://#diff-35cb53470bfd5adf8d0f4d442e0b308aaa13190231ef58ce3325013613796f9fL65-R128) [[4]](diffhunk://#diff-35cb53470bfd5adf8d0f4d442e0b308aaa13190231ef58ce3325013613796f9fR143-R148)
* Updated the license view to acknowledge and thank the `media-control` project.

**Android Communication Improvements**

* Added a new `sendMacInfoResponse` method to send detailed Mac device information (name, type, model, subscription status, installed apps) to Android devices upon pairing, with legacy and explicit keys for compatibility. [[1]](diffhunk://#diff-d4b23e9bb1b5cb14a6e6ad5a8dbd1e244b2aace638c21af7c8c558163cef1c28R289-R291) [[2]](diffhunk://#diff-d4b23e9bb1b5cb14a6e6ad5a8dbd1e244b2aace638c21af7c8c558163cef1c28R642-R686)
* Added handling for the new `macInfo` message type in the WebSocket server for future-proofing.

These changes collectively improve user control over privacy, enhance device status reporting, and ensure better interoperability with Android devices and external tools.