### PR TITLE
Forced onboarding, Onboarding styling and version number display

### DIFF
--- a/airsync-mac/Components/Custom/AboutView.swift
+++ b/airsync-mac/Components/Custom/AboutView.swift
@@ -22,6 +22,8 @@ struct AboutView: View {
                             .font(.title2)
                             .bold()
 
+                        Text("v\(Bundle.main.appVersion)")
+
                         // Profile image
                         Image("avatar")
                             .resizable()
@@ -109,6 +111,7 @@ struct AboutView: View {
                         action: {
                             if UserDefaults.standard.hasPairedDeviceOnce == true {
                                 UserDefaults.standard.hasPairedDeviceOnce = false
+                                UserDefaults.standard.resetOnboarding()
                             }
                         }
                     )

--- a/airsync-mac/Core/Storage/UserDefaults.swift
+++ b/airsync-mac/Core/Storage/UserDefaults.swift
@@ -26,7 +26,8 @@ extension UserDefaults {
         static let continueApp = "continueApp"
         static let directKeyInput = "directKeyInput"
         static let sendNowPlayingStatus = "sendNowPlayingStatus"
-    static let isMusicCardHidden = "isMusicCardHidden"
+        static let isMusicCardHidden = "isMusicCardHidden"
+        static let lastOnboarding = "lastOnboarding"
 
         static let notificationStacks = "notificationStacks"
     }
@@ -128,6 +129,32 @@ extension UserDefaults {
     var isMusicCardHidden: Bool {
         get { bool(forKey: Keys.isMusicCardHidden) }
         set { set(newValue, forKey: Keys.isMusicCardHidden) }
+    }
+    
+    // MARK: - String-based Onboarding Tracking
+    
+    var lastOnboarding: String? {
+        get { string(forKey: Keys.lastOnboarding) }
+        set { set(newValue, forKey: Keys.lastOnboarding) }
+    }
+    
+    var needsOnboarding: Bool {
+        let currentForceUpdateKey = Bundle.main.object(forInfoDictionaryKey: "ForceUpdateKey") as? String ?? "001"
+        let lastCompletedVersion = lastOnboarding
+        
+        // Show onboarding if:
+        // 1. No lastOnboarding value exists (first time user)
+        // 2. lastOnboarding doesn't match current ForceUpdateKey
+        return lastCompletedVersion == nil || lastCompletedVersion != currentForceUpdateKey
+    }
+    
+    func markOnboardingCompleted() {
+        let currentForceUpdateKey = Bundle.main.object(forInfoDictionaryKey: "ForceUpdateKey") as? String ?? "001"
+        lastOnboarding = currentForceUpdateKey
+    }
+    
+    func resetOnboarding() {
+        lastOnboarding = "000"
     }
 }
 

--- a/airsync-mac/Info.plist
+++ b/airsync-mac/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>AndroidVersion</key>
 	<string>2.0.32</string>
+	<key>ForceUpdateKey</key>
+	<string>001</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/airsync-mac/Screens/HomeScreen/HomeView.swift
+++ b/airsync-mac/Screens/HomeScreen/HomeView.swift
@@ -14,6 +14,13 @@ struct HomeView: View {
     @AppStorage("hasPairedDeviceOnce") private var hasPairedDeviceOnce: Bool = false
     @State var showOnboarding = false
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    
+    private var needsOnboarding: Bool {
+        // Show onboarding if either:
+        // 1. User has never paired a device (first time user)
+        // 2. User's lastOnboarding doesn't match current ForceUpdateKey
+        return !hasPairedDeviceOnce || UserDefaults.standard.needsOnboarding
+    }
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -34,7 +41,7 @@ struct HomeView: View {
         )
         // Show onboarding sheet when needed
         .onAppear {
-            if hasPairedDeviceOnce == false {
+            if needsOnboarding {
                 showOnboarding = true
                 appState.isOnboardingActive = true
             }

--- a/airsync-mac/Screens/OnboardingView/OnboardingView.swift
+++ b/airsync-mac/Screens/OnboardingView/OnboardingView.swift
@@ -67,6 +67,7 @@ struct OnboardingView: View {
                 case .done:
                     Color.clear.onAppear {
                         hasPairedDeviceOnce = true
+                        UserDefaults.standard.markOnboardingCompleted()
                         AppState.shared.isOnboardingActive = false
                         dismiss()
                     }

--- a/airsync-mac/Screens/OnboardingView/WelcomeView.swift
+++ b/airsync-mac/Screens/OnboardingView/WelcomeView.swift
@@ -22,10 +22,10 @@ struct WelcomeView: View {
             }
 
             Text("AirSync")
-                .font(.system(size: 48, weight: .bold))
+                .font(.system(size: 48, weight: .bold, design: .rounded))
                 .tracking(0.5)
 
-            Text("Sync notifications, clipboard, and more between your Mac and Android. First, install AirSync on your Android device.")
+            Text("The forbidden continuity for you mac and Android. (っ◕‿◕)っ")
                 .font(.title3)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -52,7 +52,10 @@ struct WelcomeView: View {
                     action: onNext
                 )
                 .transition(.identity)
+
             }
+
+            Text("v\(Bundle.main.appVersion)")
         }
     }
 }

--- a/airsync-mac/Screens/Updater/UpdaterView.swift
+++ b/airsync-mac/Screens/Updater/UpdaterView.swift
@@ -11,6 +11,10 @@ extension Bundle {
     var buildNumber: String {
         return infoDictionary?["CFBundleVersion"] as! String
     }
+
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
 }
 
 struct ContentView: View {


### PR DESCRIPTION
This pull request introduces a more robust onboarding tracking system and improves the user experience by ensuring onboarding is shown when appropriate, based on versioning. It adds a new mechanism to track onboarding completion tied to a `ForceUpdateKey` in the app's configuration, updates UI text in the onboarding flow, and displays the app version in both the About and Welcome views.

**Onboarding tracking and logic improvements:**

* Added a `ForceUpdateKey` to `Info.plist` and new logic in `UserDefaults` to track onboarding completion per app version, including methods to check if onboarding is needed, mark onboarding as completed, and reset onboarding. (`airsync-mac/Info.plist`, `airsync-mac/Core/Storage/UserDefaults.swift`) [[1]](diffhunk://#diff-0448254a72086119fc503c151597d3edcb70caf0a1c06b030387e03a3f8e62a0R7-R8) [[2]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R30) [[3]](diffhunk://#diff-eab0287afa2498444d36d37ac45f125ee37720cc4fef930488d6a0345c148b51R133-R158)
* Updated `HomeView` to use the new onboarding logic, showing the onboarding sheet if the user has never paired a device or if onboarding is required for the current version. (`airsync-mac/Screens/HomeScreen/HomeView.swift`) [[1]](diffhunk://#diff-f9823aba9affa9de878155a462c4901a4314ba80e9d0f60bc46f67864f76b8eeR18-R24) [[2]](diffhunk://#diff-f9823aba9affa9de878155a462c4901a4314ba80e9d0f60bc46f67864f76b8eeL37-R44)
* Modified `OnboardingView` to mark onboarding as completed using the new method when onboarding finishes. (`airsync-mac/Screens/OnboardingView/OnboardingView.swift`)
* Added a reset onboarding call in `AboutView` when the user resets pairing, ensuring onboarding will be shown again. (`airsync-mac/Components/Custom/AboutView.swift`)

**UI improvements:**

* Updated the Welcome screen text for a more playful introduction and changed the font style to rounded bold. (`airsync-mac/Screens/OnboardingView/WelcomeView.swift`)
* Added the app version display to both the Welcome and About views for better transparency. (`airsync-mac/Screens/OnboardingView/WelcomeView.swift`, `airsync-mac/Components/Custom/AboutView.swift`, `airsync-mac/Screens/Updater/UpdaterView.swift`) [[1]](diffhunk://#diff-57d64ea2d62f9222341e60b607a5ea0746a50ec1225ea7bd997fefe0d06efe9bR55-R58) [[2]](diffhunk://#diff-f603054a5aeb2c145018c8bfaf6d71bfae297b139f7a852ce45578ba09edaf28R25-R26) [[3]](diffhunk://#diff-c9a2d7786f70f5fd2032ebd80826b9a668916cc2131e7da5c4a5ac2c150bc916R14-R17)