### PR TITLE
Add auto-open links option and fix ADB connection with VPNs like Tailscale

### DIFF
--- a/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
+++ b/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
@@ -271,6 +271,15 @@ struct SettingsFeaturesView: View {
 
             SettingsToggleView(name: "Sync clipboard", icon: "clipboard", isOn: $appState.isClipboardSyncEnabled)
 
+            HStack {
+                Label("Auto-open shared links", systemImage: "link")
+                Spacer()
+                Toggle("", isOn: $appState.autoOpenLinks)
+                    .toggleStyle(.switch)
+                    .disabled(!appState.isClipboardSyncEnabled || !appState.isPlus)
+            }
+            .opacity(appState.isClipboardSyncEnabled && appState.isPlus ? 1.0 : 0.5)
+
             SettingsToggleView(name: "Sync notification dismissals", icon: "bell.badge", isOn: $appState.dismissNotif)
 
             SettingsToggleView(name: "Send now playing status", icon: "play.circle", isOn: $appState.sendNowPlayingStatus)


### PR DESCRIPTION
## Summary
- Add "Auto-open shared links" setting that opens URLs immediately when shared from Android
- Fix ADB wireless debugging connection failing when VPN (e.g., Tailscale) is active

## Disclaimer
I'm not a Swift developer. This PR was created with the assistance of Claude Code. I can only vouch that these changes work on my setup. Please review carefully and feel free to modify, refactor, or close if this isn't the right approach. Just hoping to contribute back!

## Changes

### 1. Auto-open shared links
When enabled, URLs shared from Android via clipboard sync open directly in the default browser without showing a "Continue browsing" notification.

- New `autoOpenLinks` setting (default: off)
- Toggle in Settings > Features, below "Sync clipboard"
- Currently follows the existing Plus feature pattern, but happy for you to change this as you see fit

### 2. ADB connection fix for VPN users
When a VPN like Tailscale is running, the Android device may report its VPN IP (e.g., `100.x.x.x`) instead of its local WiFi IP. The ADB mDNS discovery finds the device at the WiFi IP, causing a mismatch and connection failure.

**Fix:** If no mDNS services are found for the reported IP, scan all discovered services and use the first non-VPN IP found (skipping the `100.x.x.x` CGNAT range).

## Testing
- Tested auto-open with URLs shared from Android (works for me)
- Tested ADB connection with Tailscale active on both Mac and Android (works for me)

Thanks for building AirSync!