### PR TITLE
Calls

### DIFF
--- a/airsync-mac/Components/Buttons/SaveAndRestartButton.swift
+++ b/airsync-mac/Components/Buttons/SaveAndRestartButton.swift
@@ -31,7 +31,8 @@ struct SaveAndRestartButton: View {
                     name: deviceName,
                     ipAddress: ipAddress,
                     port: Int(portNumber),
-                    version: version
+                    version: version,
+                    adbPorts: []
                 )
 
                 // Save

--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -35,10 +35,6 @@ class AppState: ObservableObject {
         self.adbConnectedIP = UserDefaults.standard.string(forKey: "adbConnectedIP") ?? ""
         self.mirroringPlus = UserDefaults.standard.bool(forKey: "mirroringPlus")
         self.adbEnabled = UserDefaults.standard.bool(forKey: "adbEnabled")
-        
-        let customAdbPortValue = UserDefaults.standard.integer(forKey: "customAdbPort")
-        self.customAdbPort = customAdbPortValue > 0 ? UInt16(customAdbPortValue) : nil
-        self.useCustomAdbPort = UserDefaults.standard.bool(forKey: "useCustomAdbPort")
         self.suppressAdbFailureAlerts = UserDefaults.standard.bool(forKey: "suppressAdbFailureAlerts")
         
         self.showMenubarText = UserDefaults.standard.bool(forKey: "showMenubarText")
@@ -110,7 +106,8 @@ class AppState: ObservableObject {
                     adapterName: selectedNetworkAdapterName
                 ) ?? "N/A",
             port: port,
-            version:appVersion
+            version:appVersion,
+            adbPorts: []
         )
         self.licenseDetails = loadLicenseDetailsFromUserDefaults()
 
@@ -240,22 +237,6 @@ class AppState: ObservableObject {
     @Published var adbEnabled: Bool {
         didSet {
             UserDefaults.standard.set(adbEnabled, forKey: "adbEnabled")
-        }
-    }
-
-    @Published var customAdbPort: UInt16? = nil {
-        didSet {
-            if let port = customAdbPort, port > 0 && port <= 65535 {
-                UserDefaults.standard.set(Int(port), forKey: "customAdbPort")
-            } else {
-                UserDefaults.standard.removeObject(forKey: "customAdbPort")
-            }
-        }
-    }
-
-    @Published var useCustomAdbPort: Bool {
-        didSet {
-            UserDefaults.standard.set(useCustomAdbPort, forKey: "useCustomAdbPort")
         }
     }
 

--- a/airsync-mac/Core/WebSocket/WebSocketServer.swift
+++ b/airsync-mac/Core/WebSocket/WebSocketServer.swift
@@ -296,12 +296,14 @@ class WebSocketServer: ObservableObject {
                let port = dict["port"] as? Int {
 
                 let version = dict["version"] as? String ?? "2.0.0"
+                let adbPorts = dict["adbPorts"] as? [String] ?? []
 
                 AppState.shared.device = Device(
                     name: name,
                     ipAddress: ip,
                     port: port,
-                    version: version
+                    version: version,
+                    adbPorts: adbPorts
                 )
 
                 if let base64 = dict["wallpaper"] as? String {

--- a/airsync-mac/Model/Device.swift
+++ b/airsync-mac/Model/Device.swift
@@ -14,9 +14,10 @@ struct Device: Codable, Hashable, Identifiable {
     let ipAddress: String
     let port: Int
     let version: String
+    let adbPorts: [String]
 
     private enum CodingKeys: String, CodingKey {
-        case name, ipAddress, port, version
+        case name, ipAddress, port, version, adbPorts
     }
 }
 
@@ -25,7 +26,8 @@ struct MockData{
         name: "Test Device",
         ipAddress: "192.168.1.100",
         port: 8080,
-        version: "2.0.0"
+        version: "2.0.0",
+        adbPorts: ["5555"]
     )
 
     static let sampleNotificaiton = Notification(
@@ -48,8 +50,8 @@ struct MockData{
     )
 
     static let sampleDevices = [
-        Device(name: "Test Device 1", ipAddress: "192.168.1.101", port: 8080, version: "2.0.0"),
-        Device(name: "Test Device 2", ipAddress: "192.168.1.102", port: 8080, version: "2.0.0"),
-        Device(name: "Test Device 3", ipAddress: "192.168.1.103", port: 8080, version: "2.0.0")
+        Device(name: "Test Device 1", ipAddress: "192.168.1.101", port: 8080, version: "2.0.0", adbPorts: ["5555"]),
+        Device(name: "Test Device 2", ipAddress: "192.168.1.102", port: 8080, version: "2.0.0", adbPorts: ["5555"]),
+        Device(name: "Test Device 3", ipAddress: "192.168.1.103", port: 8080, version: "2.0.0", adbPorts: ["5555"])
     ]
 }

--- a/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
+++ b/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
@@ -19,7 +19,6 @@ struct SettingsFeaturesView: View {
     @AppStorage("continueApp") private var continueApp = false
     @AppStorage("directKeyInput") private var directKeyInput = true
 
-    @State private var adbPortString: String = ""
     @State private var showingPlusPopover = false
     @State private var tempBitrate: Double = 4.00
     @State private var tempResolution: Double = 1200.00
@@ -62,7 +61,7 @@ struct SettingsFeaturesView: View {
                             }
                         )
                         .disabled(
-                            adbPortString.isEmpty || appState.device == nil || appState.adbConnecting || !AppState.shared.isPlus
+                            appState.device == nil || (appState.device?.adbPorts.isEmpty ?? true) || appState.adbConnecting || !AppState.shared.isPlus
                         )
                     }
 
@@ -79,6 +78,19 @@ struct SettingsFeaturesView: View {
                     }
                     .frame(width: 55)
 
+                }
+                
+                // Show message when no ADB ports available
+                if let device = appState.device, device.adbPorts.isEmpty {
+                    HStack {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(.orange)
+                        Text("ADB ports not available. Ensure device is properly connected.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    .padding(.top, 8)
                 }
                 
                 // Transparent tap area on top to show popover even if disabled
@@ -267,8 +279,6 @@ struct SettingsFeaturesView: View {
         }
         .padding()
         .onAppear{
-
-            adbPortString = String(appState.adbPort)
             xCoords = UserDefaults.standard.manualPositionCoords[0]
             yCoords = UserDefaults.standard.manualPositionCoords[1]
         }
@@ -343,7 +353,6 @@ struct SettingsFeaturesView: View {
         }
         .padding()
         .onAppear{
-            adbPortString = String(appState.adbPort)
             checkNotificationPermissions()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in

--- a/airsync-mac/Screens/Settings/SettingsView.swift
+++ b/airsync-mac/Screens/Settings/SettingsView.swift
@@ -69,28 +69,6 @@ struct SettingsView: View {
                                 }
                                 .frame(maxWidth: 100)
                         }
-
-                        HStack {
-                            Label("Custom ADB Port", systemImage: "powerplug.portrait")
-                                .padding(.trailing, 20)
-                            Spacer()
-                            TextField("Port", text: Binding(
-                                get: { appState.customAdbPort.map(String.init) ?? "" },
-                                set: { newValue in
-                                    let filtered = newValue.filter { "0123456789".contains($0) }
-                                    if let portNum = UInt16(filtered), portNum > 0 && portNum <= 65535 {
-                                        appState.customAdbPort = portNum
-                                    } else if filtered.isEmpty {
-                                        appState.customAdbPort = nil
-                                    }
-                                }
-                            ))
-                                .textFieldStyle(.roundedBorder)
-                                .frame(maxWidth: 100)
-
-                            Toggle("", isOn: $appState.useCustomAdbPort)
-                                .toggleStyle(.switch)
-                        }
                     }
                     .padding()
                     .background(.background.opacity(0.3))


### PR DESCRIPTION
This pull request introduces improvements to ADB connection handling and device state management in the AirSync macOS app. The main focus is on making ADB port selection more robust, preventing duplicate connection attempts, and enhancing user feedback for connection failures. Additionally, new state properties are added to track ADB connection details and user preferences regarding error alerts.

**ADB Connection Handling Improvements**
* The ADB connection logic in `ADBConnector.swift` now uses ADB port information provided by the device, removes mDNS discovery, and attempts connections on all reported ports, including fallback to the originally reported IP if needed. It also prevents concurrent connection attempts by using a lock and a flag. [[1]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2R24-R27) [[2]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2R81-R240) [[3]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2R305-R322) [[4]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2L279-R333)
* User-facing error alerts for ADB connection failures now include a "Don't warn me again" option, allowing users to suppress future alerts. The suppression state is stored in `AppState`. [[1]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2R258-R284) [[2]](diffhunk://#diff-520fe8ffe9c28b570d0285ca6bcb51aa82104f894c58a40b560ec664f05917c2R81-R240)

**Device State and Persistence**
* The `Device` model and related code now include an `adbPorts` field, which is populated from WebSocket messages and used for ADB connection attempts. [[1]](diffhunk://#diff-d4b23e9bb1b5cb14a6e6ad5a8dbd1e244b2aace638c21af7c8c558163cef1c28R299-R306) [[2]](diffhunk://#diff-798b63b955ef81bba87da65e31c6b3dda967d3bbea1f304944d8f6eae30a6de6L34-R35) [[3]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefL106-R110)
* New published properties are added to `AppState` to store the connected ADB IP (`adbConnectedIP`) and the user's preference to suppress ADB failure alerts (`suppressAdbFailureAlerts`). These are persisted in `UserDefaults`. [[1]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR35-R39) [[2]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR222-R228) [[3]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR243-R248)

**Other Improvements**
* The handling of incoming calls in `AppState` is improved to update the UI when a call is answered.
* Minor reordering of `AppState` properties for clarity.

These changes collectively improve reliability and user experience when connecting to Android devices via ADB over Wi-Fi.