### PR TITLE
add feature of selecting dpi when using desktop mode

### DIFF
--- a/airsync-mac/Core/Util/CLI/ADBConnector.swift
+++ b/airsync-mac/Core/Util/CLI/ADBConnector.swift
@@ -505,7 +505,13 @@ Attempt \(portNumber)/\(totalPorts) on port \(currentPort): Failed - \(trimmedOu
         }
 
         if desktop ?? true {
-            args.append("--new-display=\(desktopMode ?? "1600x1000")")
+            let res = desktopMode ?? "1600x1000"
+            let dpi = UserDefaults.standard.string(forKey: "scrcpyDesktopDpi") ?? ""
+            if !dpi.isEmpty {
+                args.append("--new-display=\(res)/\(dpi)")
+            } else {
+                args.append("--new-display=\(res)")
+            }
         }
 
         if let pkg = package {

--- a/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
+++ b/airsync-mac/Screens/Settings/SettingsFeaturesView.swift
@@ -18,6 +18,7 @@ struct SettingsFeaturesView: View {
     @AppStorage("manualPosition") private var manualPosition = false
     @AppStorage("continueApp") private var continueApp = false
     @AppStorage("directKeyInput") private var directKeyInput = true
+    @AppStorage("scrcpyDesktopDpi") private var scrcpyDesktopDpi = ""
 
     @State private var showingPlusPopover = false
     @State private var tempBitrate: Double = 4.00
@@ -214,6 +215,19 @@ struct SettingsFeaturesView: View {
                                         Text("2000x1800").tag("2000x1800")
                                     }
                                     .pickerStyle(MenuPickerStyle())
+                                }
+
+                                HStack {
+                                    Text("dpi")
+                                    Spacer()
+                                    TextField("dpi", text: Binding(
+                                        get: { UserDefaults.standard.string(forKey: "scrcpyDesktopDpi") ?? "" },
+                                        set: { newValue in
+                                            UserDefaults.standard.set(newValue.filter { "0123456789".contains($0) }, forKey: "scrcpyDesktopDpi")
+                                        }
+                                    ))
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(maxWidth: 60)
                                 }
 
                                 HStack{


### PR DESCRIPTION
Adds the option to select dpi too.

So this image is without selecting dpi (normal devices dpi)
and the command is:
scrcpy --new-display=2560x1200

<img width="1340" height="669" alt="Screenshot 2026-03-04 at 5 29 49 PM" src="https://github.com/user-attachments/assets/a4233c33-847a-4c09-bbd9-6a87c2777582" />


And this is image with a custom dpi (120)
and the command is:
scrcpy --new-display=2560x1200/120
Helps scaling everything perfectly in the desktop mode:
<img width="1351" height="670" alt="Screenshot 2026-03-04 at 5 30 29 PM" src="https://github.com/user-attachments/assets/f609c39b-1e0b-4bdd-adf3-233ace0ef003" />




