### PR TITLE
feat: Add a notification silence button in menu bar

### DIFF
--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -52,6 +52,7 @@ class AppState: ObservableObject {
         self.alwaysOpenWindow = UserDefaults.standard.bool(forKey: "alwaysOpenWindow")
         self.notificationSound = UserDefaults.standard.string(forKey: "notificationSound") ?? "default"
         self.dismissNotif = UserDefaults.standard.bool(forKey: "dismissNotif")
+        self.silenceAllNotifications = UserDefaults.standard.bool(forKey: "silenceAllNotifications")
         
         self.autoAcceptQuickShare = UserDefaults.standard.bool(forKey: "autoAcceptQuickShare")
         self.quickShareEnabled = UserDefaults.standard.object(forKey: "quickShareEnabled") == nil ? true : UserDefaults.standard.bool(forKey: "quickShareEnabled")
@@ -305,6 +306,16 @@ class AppState: ObservableObject {
     @Published var dismissNotif: Bool {
         didSet {
             UserDefaults.standard.set(dismissNotif, forKey: "dismissNotif")
+        }
+    }
+
+    @Published var silenceAllNotifications: Bool {
+        didSet {
+            UserDefaults.standard.set(silenceAllNotifications, forKey: "silenceAllNotifications")
+            if silenceAllNotifications {
+                UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+                UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+            }
         }
     }
 
@@ -571,6 +582,10 @@ class AppState: ObservableObject {
     }
 
     private func postCallSystemNotification(_ callEvent: CallEvent) {
+        if silenceAllNotifications {
+            return
+        }
+
         let center = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
 
@@ -786,6 +801,10 @@ class AppState: ObservableObject {
         extraActions: [UNNotificationAction] = [],
         extraUserInfo: [String: Any] = [:]
     ) {
+        if silenceAllNotifications {
+            return
+        }
+
         let center = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
         content.title = "\(appName) - \(title)"

--- a/airsync-mac/Screens/MenubarView/MenubarView.swift
+++ b/airsync-mac/Screens/MenubarView/MenubarView.swift
@@ -165,6 +165,16 @@ struct MenubarView: View {
                     }
 
                     GlassButtonView(
+                        label: appState.silenceAllNotifications ? "Disable DND" : "Enable DND",
+                        systemImage: appState.silenceAllNotifications ? "bell.slash.fill" : "bell.badge",
+                        iconOnly: true,
+                        circleSize: toolButtonSize
+                    ) {
+                        appState.silenceAllNotifications.toggle()
+                    }
+                    .help(appState.silenceAllNotifications ? "Do Not Disturb is ON" : "Turn on Do Not Disturb")
+
+                    GlassButtonView(
                         label: "Quit",
                         systemImage: "power",
                         iconOnly: true,


### PR DESCRIPTION
Now you can silence the notifications more like a DND/Focus mode while the notifications keep syncing in background but does not distract you with the sound and popup

<img width="327" height="481" alt="image" src="https://github.com/user-attachments/assets/05957c4d-6a05-4423-88dd-a1c376b2e999" />
