### PR TITLE
Develop - reconnect error reporting fix

### DIFF
--- a/AirSync.xcodeproj/project.pbxproj
+++ b/AirSync.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "sameerasw.airsync-mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -477,7 +477,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "sameerasw.airsync-mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -525,7 +525,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "sameerasw.airsync-mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/airsync-mac/Core/QuickConnect/QuickConnectManager.swift
+++ b/airsync-mac/Core/QuickConnect/QuickConnectManager.swift
@@ -224,19 +224,38 @@ class QuickConnectManager: ObservableObject {
         request.httpBody = message.data(using: .utf8)
         request.timeoutInterval = 5.0
         
+        var success = false
+        
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 200 {
                     print("[quick-connect] Wake-up request successful - device should reconnect soon")
+                    success = true
+                } else if httpResponse.statusCode == 502 {
+                    print("[quick-connect] Wake-up request failed with 502 (Bad Gateway). Retrying once...")
+                    
+                    // Small delay before retry
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    
+                    if let (_, secondResponse) = try? await URLSession.shared.data(for: request),
+                       let secondHttpResponse = secondResponse as? HTTPURLResponse,
+                       secondHttpResponse.statusCode == 200 {
+                        print("[quick-connect] Wake-up retry successful")
+                        success = true
+                    } else {
+                        print("[quick-connect] Wake-up retry failed")
+                    }
                 } else {
                     print("[quick-connect] Wake-up request failed with status: \(httpResponse.statusCode)")
                 }
             }
         } catch {
             print("[quick-connect] Failed to send wake-up request: \(error)")
-            
+        }
+        
+        if !success {
             // Fallback: Try UDP broadcast
             await sendUDPWakeUpRequest(to: device, message: message)
         }

--- a/airsync-mac/Core/SentryInitializer.swift
+++ b/airsync-mac/Core/SentryInitializer.swift
@@ -25,6 +25,12 @@ struct SentryInitializer {
             options.sendDefaultPii = true
             
             options.beforeSend = { event in
+                // Ignore transient wake-up failures (often 502/timeout while device is waking up)
+                if let request = event.request, let url = request.url, url.contains("/wakeup") {
+                    print("[SentryInitializer] Filtering out transient wake-up error for: \(url)")
+                    return nil
+                }
+                
                 if let exceptions = event.exceptions,
                    let firstException = exceptions.first,
                    firstException.type == "App Hanging" {


### PR DESCRIPTION
This pull request introduces a minor version bump and implements improvements to error handling and reporting for wake-up requests. The most significant changes include retry logic for transient network errors in quick connect, filtering out noisy errors from Sentry reporting, and updating the app version.

Enhancements to wake-up request reliability:

* Added retry logic in `QuickConnectManager.swift` for HTTP 502 errors during wake-up requests, including a short delay and a fallback to UDP broadcast if both attempts fail.

Error reporting improvements:

* Updated `SentryInitializer.swift` to filter out transient wake-up errors (e.g., 502 or timeouts) from Sentry error reporting, reducing noise from expected failures during device wake-up.

Versioning:

* Bumped `MARKETING_VERSION` from 3.1.0 to 3.1.1 in `AirSync.xcodeproj/project.pbxproj` to reflect these changes. [[1]](diffhunk://#diff-925c11bc84e137561690b314119c3f7d90237eed22d4aed56f06ab830c0585eeL304-R304) [[2]](diffhunk://#diff-925c11bc84e137561690b314119c3f7d90237eed22d4aed56f06ab830c0585eeL480-R480) [[3]](diffhunk://#diff-925c11bc84e137561690b314119c3f7d90237eed22d4aed56f06ab830c0585eeL528-R528)