### PR TITLE
Web dav file access impl

### DIFF
--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -57,6 +57,7 @@ class AppState: ObservableObject {
         
         self.autoAcceptQuickShare = UserDefaults.standard.bool(forKey: "autoAcceptQuickShare")
         self.quickShareEnabled = UserDefaults.standard.object(forKey: "quickShareEnabled") == nil ? true : UserDefaults.standard.bool(forKey: "quickShareEnabled")
+        self.isFileAccessEnabled = UserDefaults.standard.object(forKey: "isFileAccessEnabled") == nil ? true : UserDefaults.standard.bool(forKey: "isFileAccessEnabled")
 
         let savedNotificationMode = UserDefaults.standard.string(forKey: "callNotificationMode") ?? CallNotificationMode.popup.rawValue
         self.callNotificationMode = CallNotificationMode(rawValue: savedNotificationMode) ?? .popup
@@ -151,7 +152,7 @@ class AppState: ObservableObject {
                 loadRecentApps()
 
                 // Mount WebDAV volume
-                if newDevice.ipAddress != "BLE" {
+                if newDevice.ipAddress != "BLE" && isPlus && isFileAccessEnabled {
                     WebDAVManager.shared.mount(ipAddress: newDevice.ipAddress, port: 9081, volumeName: newDevice.name)
                 }
             } else {
@@ -438,6 +439,27 @@ class AppState: ObservableObject {
         }
     }
 
+    @Published var isFileAccessEnabled: Bool {
+        didSet {
+            if !isPlus && licenseCheck {
+                if isFileAccessEnabled {
+                    isFileAccessEnabled = false
+                }
+                UserDefaults.standard.set(false, forKey: "isFileAccessEnabled")
+                WebDAVManager.shared.unmount()
+            } else {
+                UserDefaults.standard.set(isFileAccessEnabled, forKey: "isFileAccessEnabled")
+                if isFileAccessEnabled {
+                    if let newDevice = device, newDevice.ipAddress != "BLE" {
+                        WebDAVManager.shared.mount(ipAddress: newDevice.ipAddress, port: 9081, volumeName: newDevice.name)
+                    }
+                } else {
+                    WebDAVManager.shared.unmount()
+                }
+            }
+        }
+    }
+
     @Published var isCrashReportingEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isCrashReportingEnabled, forKey: "isCrashReportingEnabled")
@@ -481,6 +503,11 @@ class AppState: ObservableObject {
         didSet {
             if !shouldSkipSave {
                 UserDefaults.standard.set(isPlus, forKey: "isPlus")
+            }
+            if !isPlus && licenseCheck {
+                if isFileAccessEnabled {
+                    isFileAccessEnabled = false
+                }
             }
             // Notify about license status change for icon revert logic
             NotificationCenter.default.post(name: NSNotification.Name("LicenseStatusChanged"), object: nil)

--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -134,6 +134,9 @@ class AppState: ObservableObject {
 
         // Reset mirroring state on launch to prevent auto-opening if it was open during last session
         self.isNativeMirroring = false
+
+        // Cleanup stale WebDAV mounts from previous sessions
+        WebDAVManager.shared.unmount()
     }
 
     @Published var minAndroidVersion = Bundle.main.infoDictionary?["AndroidVersion"] as? String ?? "2.0.0"
@@ -146,8 +149,14 @@ class AppState: ObservableObject {
                 // Validate pinned apps when connecting to a device
                 validatePinnedApps()
                 loadRecentApps()
+
+                // Mount WebDAV volume
+                if newDevice.ipAddress != "BLE" {
+                    WebDAVManager.shared.mount(ipAddress: newDevice.ipAddress, port: 9081, volumeName: newDevice.name)
+                }
             } else {
                 recentApps = []
+                WebDAVManager.shared.unmount()
             }
 
             // Automatically switch to the appropriate tab when device connection state changes

--- a/airsync-mac/Core/Storage/WebDAVManager.swift
+++ b/airsync-mac/Core/Storage/WebDAVManager.swift
@@ -1,0 +1,96 @@
+//
+//  WebDAVManager.swift
+//  airsync-mac
+//
+//  Created by Sameera Sandakelum on 2026-05-21.
+//
+
+import Foundation
+import Cocoa
+
+class WebDAVManager {
+    static let shared = WebDAVManager()
+    
+    private let mountPoint = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Caches/com.airsync.mac/AndroidVolume")
+    
+    private var isMounted = false
+    
+    private init() {}
+    
+    func mount(ipAddress: String, port: Int = 9081, volumeName: String = "Android") {
+        guard !isMounted else { return }
+        
+        let urlString = "http://\(ipAddress):\(port)/"
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            // 1. Force unmount and clean directory
+            self.unmountSilently()
+            
+            do {
+                if FileManager.default.fileExists(atPath: self.mountPoint.path) {
+                    try? FileManager.default.removeItem(at: self.mountPoint)
+                }
+                try FileManager.default.createDirectory(at: self.mountPoint, withIntermediateDirectories: true)
+                
+                // 2. Mount the WebDAV server
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/sbin/mount_webdav")
+                
+                // WebDAV URLs should have a trailing slash for the root
+                let finalUrl = urlString.hasSuffix("/") ? urlString : "\(urlString)/"
+                
+                print("[webdav] Attempting to mount \(finalUrl) to \(self.mountPoint.path)")
+                
+                // Revert to simple command that works
+                process.arguments = [finalUrl, self.mountPoint.path]
+                
+                try process.run()
+                process.waitUntilExit()
+                
+                if process.terminationStatus == 0 {
+                    self.isMounted = true
+                    print("[webdav] Successfully mounted Android volume")
+                    
+                    // Automatically open the folder in Finder for the user
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        self.openInFinder()
+                    }
+                } else {
+                    print("[webdav] Failed to mount WebDAV volume. Status: \(process.terminationStatus)")
+                }
+            } catch {
+                print("[webdav] Error in mount process: \(error)")
+            }
+        }
+    }
+    
+    func unmount() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.unmountSilently()
+            self.isMounted = false
+        }
+    }
+    
+    private func unmountSilently() {
+        // Try diskutil first
+        let diskutil = Process()
+        diskutil.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+        diskutil.arguments = ["unmount", "force", self.mountPoint.path]
+        try? diskutil.run()
+        diskutil.waitUntilExit()
+        
+        // Fallback to umount if directory still exists or diskutil failed
+        let umount = Process()
+        umount.executableURL = URL(fileURLWithPath: "/sbin/umount")
+        umount.arguments = ["-f", self.mountPoint.path]
+        try? umount.run()
+        umount.waitUntilExit()
+    }
+    
+    func openInFinder() {
+        if FileManager.default.fileExists(atPath: mountPoint.path) {
+            NSWorkspace.shared.open(mountPoint)
+        }
+    }
+}

--- a/airsync-mac/Core/Storage/WebDAVManager.swift
+++ b/airsync-mac/Core/Storage/WebDAVManager.swift
@@ -51,11 +51,6 @@ class WebDAVManager {
                 if process.terminationStatus == 0 {
                     self.isMounted = true
                     print("[webdav] Successfully mounted Android volume")
-                    
-                    // Automatically open the folder in Finder for the user
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        self.openInFinder()
-                    }
                 } else {
                     print("[webdav] Failed to mount WebDAV volume. Status: \(process.terminationStatus)")
                 }

--- a/airsync-mac/Localization/en.json
+++ b/airsync-mac/Localization/en.json
@@ -62,5 +62,8 @@
   "quickshare.n_files": "%d files",
   "quickshare.drop.send_to": "Send to %@",
   "quickshare.drop.pick_device": "Pick a device to send",
-  "settings.quickshare": "Quick Share"
+  "settings.quickshare": "Quick Share and Files",
+  "settings.fileAccess.title": "File Access",
+  "settings.fileAccess.enabled": "Enable File Access",
+  "settings.fileAccess.description": "Mount your Android device storage as a local drive in macOS Finder automatically."
 }

--- a/airsync-mac/Localization/en.json
+++ b/airsync-mac/Localization/en.json
@@ -1,6 +1,7 @@
 {
   "app.name": "AirSync",
   "menu.mirror": "Mirror",
+  "menu.browseFiles": "Browse Files",
   "menu.about": "About AirSync",
   "menu.checkUpdates": "Check for Updates…",
   "menu.quit": "Quit",

--- a/airsync-mac/Screens/MenubarView/MenubarSegments.swift
+++ b/airsync-mac/Screens/MenubarView/MenubarSegments.swift
@@ -73,6 +73,16 @@ struct TopSegmentView: View {
                             openQuickShare()
                         }
                     )
+
+                    GlassButtonView(
+                        label: L("menu.browseFiles"),
+                        systemImage: "folder",
+                        iconOnly: true,
+                        circleSize: toolButtonSize,
+                        action: {
+                            WebDAVManager.shared.openInFinder()
+                        }
+                    )
                     
                     if appState.adbConnected {
                         GlassButtonView(

--- a/airsync-mac/Screens/Settings/SettingsView.swift
+++ b/airsync-mac/Screens/Settings/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @State private var availableAdapters: [(name: String, address: String)] = []
     @State private var currentIPAddress: String = "N/A"
     @State private var showRemoteSheet = false
+    @State private var showingPlusPopover = false
 
     var body: some View {
         Group {
@@ -161,6 +162,47 @@ struct SettingsView: View {
                                 .toggleStyle(.switch)
                         }
                     }
+                }
+                .padding()
+                .glassBoxIfAvailable(radius: 18)
+
+                headerSection(title: Localizer.shared.text("settings.fileAccess.title"), icon: "folder.badge.gearshape")
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        ZStack {
+                            HStack {
+                                Label(Localizer.shared.text("settings.fileAccess.enabled"), systemImage: "externaldrive")
+                                Spacer()
+                                Toggle("", isOn: $appState.isFileAccessEnabled)
+                                    .toggleStyle(.switch)
+                                    .disabled(!AppState.shared.isPlus && AppState.shared.licenseCheck)
+                            }
+
+                            if !AppState.shared.isPlus && AppState.shared.licenseCheck {
+                                HStack {
+                                    Spacer()
+                                    Rectangle()
+                                        .fill(Color.clear)
+                                        .contentShape(Rectangle())
+                                        .onTapGesture {
+                                            showingPlusPopover = true
+                                        }
+                                        .frame(width: 500)
+                                }
+                            }
+                        }
+                    }
+                    .popover(isPresented: $showingPlusPopover, arrowEdge: .bottom) {
+                        PlusFeaturePopover(message: "File Access feature is available in AirSync+")
+                            .onTapGesture {
+                                showingPlusPopover = false
+                            }
+                    }
+
+                    Text(Localizer.shared.text("settings.fileAccess.description"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding()
                 .glassBoxIfAvailable(radius: 18)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to mount their Android device storage as a local drive on macOS using WebDAV. It adds the necessary UI, settings, and logic to enable or disable this feature, and ensures it is only available to AirSync+ users. The changes also include localization updates and integration with the existing device connection workflow.

**New File Access Feature (WebDAV integration):**

* Added a new `WebDAVManager` class to handle mounting and unmounting the Android device storage as a WebDAV volume in macOS Finder, including methods for mounting, unmounting, and opening the volume in Finder. (`airsync-mac/Core/Storage/WebDAVManager.swift`)
* Integrated WebDAV mounting/unmounting into the app lifecycle: mounts the volume when a compatible device connects and unmounts it when disconnected or on app launch; also cleans up stale mounts. (`airsync-mac/Core/AppState.swift`) [[1]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR138-R140) [[2]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR153-R160)

**Settings and User Interface:**

* Added a new toggle in the Settings view to enable or disable File Access, with a description and gating for AirSync+ users (including a popover explaining the feature restriction). (`airsync-mac/Screens/Settings/SettingsView.swift`)
* Added a "Browse Files" button to the menubar for quick access to the mounted Android volume. (`airsync-mac/Screens/MenubarView/MenubarSegments.swift`)

**Localization and User Experience:**

* Updated localization strings to include new menu and settings items for File Access. (`airsync-mac/Localization/en.json`) [[1]](diffhunk://#diff-ccc0c09b7acd8d37a48d0b5ee471df927539a71b1a73b8949c0e9156c9318079R4) [[2]](diffhunk://#diff-ccc0c09b7acd8d37a48d0b5ee471df927539a71b1a73b8949c0e9156c9318079L64-R68)

**Access Control and State Management:**

* Enforced that File Access is only available to AirSync+ users by disabling the toggle and auto-reverting the setting if the user is not eligible. Also ensures UserDefaults and state are kept in sync and unmounts the drive if access is revoked. (`airsync-mac/Core/AppState.swift`) [[1]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR442-R462) [[2]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR507-R511) [[3]](diffhunk://#diff-490978fab216efc8c4241c44fffe1535df2f1159b4ba618e3f806e7c6efa2aefR60)