### PR TITLE
fix(notification): resolve duplicate cards, focus-mode auto-dismissal, and local hide behavior

### DIFF
--- a/airsync-mac/Core/AppState.swift
+++ b/airsync-mac/Core/AppState.swift
@@ -943,7 +943,7 @@ class AppState: ObservableObject {
             withAnimation {
                 self.notifications.removeAll { $0.id == notif.id }
             }
-            self.removeNotification(notif)
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notif.nid])
         }
     }
 
@@ -1058,12 +1058,19 @@ class AppState: ObservableObject {
 
     func addNotification(_ notif: Notification) {
         DispatchQueue.main.async {
+            var contentChanged = true
             withAnimation {
-                self.notifications.insert(notif, at: 0)
+                if let idx = self.notifications.firstIndex(where: { $0.nid == notif.nid }) {
+                    let old = self.notifications[idx]
+                    contentChanged = (old.title != notif.title || old.body != notif.body || old.actions != notif.actions)
+                    self.notifications[idx] = notif
+                } else {
+                    self.notifications.insert(notif, at: 0)
+                }
             }
-            // Trigger native macOS notification if not silent
+            // Trigger native macOS notification if not silent and content actually changed/new
             // Default to alerting if priority is missing (backwards compatibility)
-            if notif.priority != "silent" {
+            if notif.priority != "silent" && contentChanged {
                 var appIcon: NSImage? = nil
                 if let iconPath = self.androidApps[notif.package]?.iconUrl {
                     appIcon = NSImage(contentsOfFile: iconPath)
@@ -1196,17 +1203,22 @@ class AppState: ObservableObject {
     }
 
     func syncWithSystemNotifications() {
-        UNUserNotificationCenter.current().getDeliveredNotifications { systemNotifs in
-            let systemNIDs = Set(systemNotifs.map { $0.request.identifier })
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else {
+                return
+            }
+            UNUserNotificationCenter.current().getDeliveredNotifications { systemNotifs in
+                let systemNIDs = Set(systemNotifs.map { $0.request.identifier })
 
-            DispatchQueue.main.async {
-                // Only sync notifications that were actually posted to system (non-silent)
-                let currentSystemNIDs = Set(self.notifications.filter { $0.priority != "silent" }.map { $0.nid })
-                let removedNIDs = currentSystemNIDs.subtracting(systemNIDs)
+                DispatchQueue.main.async {
+                    // Only sync notifications that were actually posted to system (non-silent)
+                    let currentSystemNIDs = Set(self.notifications.filter { $0.priority != "silent" }.map { $0.nid })
+                    let removedNIDs = currentSystemNIDs.subtracting(systemNIDs)
 
-                for nid in removedNIDs {
-                    print("[state] (notification) System notification \(nid) was dismissed manually.")
-                    self.removeNotificationById(nid)
+                    for nid in removedNIDs {
+                        print("[state] (notification) System notification \(nid) was dismissed manually.")
+                        self.removeNotificationById(nid)
+                    }
                 }
             }
         }

--- a/airsync-mac/Core/Util/NotificationDelegate.swift
+++ b/airsync-mac/Core/Util/NotificationDelegate.swift
@@ -11,16 +11,6 @@ import UserNotifications
 @MainActor
 class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                didRemoveDeliveredNotifications identifiers: [String]) {
-        for nid in identifiers {
-            print("[notification-delegate] User dismissed system notification with nid: \(nid)")
-            DispatchQueue.main.async {
-                AppState.shared.removeNotificationById(nid)
-            }
-        }
-    }
-
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound])


### PR DESCRIPTION
Verify Duplicate Card Prevention:
1 - Send a notification from Android (e.g., ID 123).
2 - Send the exact same notification again. Confirm no duplicate card is added and no new sound/banner triggers.
3 - Send an updated version (same ID 123, modified text). Confirm the card updates in-place and triggers a native alert.
For example, if a background process or music player keeps sending the exact same notification state (same ID, same title, same body) to the Mac repeatedly, the Mac app will now update the existing card in place instead of piling up identical duplicate cards in your list, and it won't keep playing alert sounds for unchanged content.

Verify Focus Mode / DND Sync Behavior:
1 - Turn on Do Not Disturb or disable notifications for the app in macOS System Settings.
2 - Send a notification.
3 - Confirm that notifications persist in the Mac UI and are not incorrectly auto-deleted by the sync process.
 
Verify Local Dismissal (Hide):
1 - Click Hide on a notification card in the Mac app.
2 - Confirm the card is dismissed only on Mac and remains active on Android.